### PR TITLE
Port over tests from CALC

### DIFF
--- a/uswds_forms/tests/conftest.py
+++ b/uswds_forms/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 
 
 APP_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -31,7 +30,6 @@ SETTINGS_DICT = {
 }
 
 
-@pytest.fixture(scope="session", autouse=True)
 def init_django():
     # Making Django run this way is a two-step process. First, call
     # settings.configure() to give Django settings to work with:
@@ -42,3 +40,9 @@ def init_django():
     # and other bits:
     import django
     django.setup()
+
+
+# Originally we defined this as a session-scoped fixture, but that
+# broke django.test.SimpleTestCase instances' class setup methods,
+# so we need to call this function *really* early.
+init_django()

--- a/uswds_forms/tests/test_date.py
+++ b/uswds_forms/tests/test_date.py
@@ -6,6 +6,12 @@ from uswds_forms.date import UswdsDateWidget, UswdsDateField
 
 
 class DateWidgetTests(SimpleTestCase):
+    def test_get_field_names_works(self):
+        names = UswdsDateWidget.get_field_names('boop')
+        self.assertEqual(names.year, 'boop_0')
+        self.assertEqual(names.month, 'boop_1')
+        self.assertEqual(names.day, 'boop_2')
+
     def test_render_assigns_ids_and_labels(self):
         widget = UswdsDateWidget()
         content = widget.render('boop', None, {'id': 'blarg'})

--- a/uswds_forms/tests/test_date.py
+++ b/uswds_forms/tests/test_date.py
@@ -1,0 +1,79 @@
+from datetime import date
+from django.test import SimpleTestCase
+from django.core.exceptions import ValidationError
+
+from uswds_forms.date import UswdsDateWidget, UswdsDateField
+
+
+class DateWidgetTests(SimpleTestCase):
+    def test_render_assigns_ids_and_labels(self):
+        widget = UswdsDateWidget()
+        content = widget.render('boop', None, {'id': 'blarg'})
+        self.assertRegexpMatches(content, 'id="blarg_0"')
+        self.assertRegexpMatches(content, 'id="blarg_1"')
+        self.assertRegexpMatches(content, 'id="blarg_2"')
+        self.assertRegexpMatches(content, 'for="blarg_0"')
+        self.assertRegexpMatches(content, 'for="blarg_1"')
+        self.assertRegexpMatches(content, 'for="blarg_2"')
+
+    def test_render_assigns_names(self):
+        widget = UswdsDateWidget()
+        content = widget.render('boop', None, {'id': 'blarg'})
+        self.assertRegexpMatches(content, 'name="boop_0"')
+        self.assertRegexpMatches(content, 'name="boop_1"')
+        self.assertRegexpMatches(content, 'name="boop_2"')
+
+    def test_render_assigns_hint_id_and_aria_describedby(self):
+        widget = UswdsDateWidget()
+        content = widget.render('boop', None, {'id': 'foo'})
+        self.assertRegexpMatches(content, 'id="foo_hint"')
+        self.assertRegexpMatches(content, 'aria-describedby="foo_hint"')
+
+    def test_render_takes_value_as_list(self):
+        widget = UswdsDateWidget()
+        content = widget.render('boop', [2006, 7, 29], {'id': 'foo'})
+        self.assertRegexpMatches(content, 'value="2006"')
+        self.assertRegexpMatches(content, 'value="7"')
+        self.assertRegexpMatches(content, 'value="29"')
+
+    def test_render_takes_value_as_date(self):
+        widget = UswdsDateWidget()
+        content = widget.render('boop', date(2005, 6, 28), {'id': 'foo'})
+        self.assertRegexpMatches(content, 'value="2005"')
+        self.assertRegexpMatches(content, 'value="6"')
+        self.assertRegexpMatches(content, 'value="28"')
+
+    def test_render_does_not_raise_exception_on_empty_lists(self):
+        widget = UswdsDateWidget()
+        content = widget.render('boop', [], {'id': 'foo'})
+
+        # The <input>s should not have any 'value' attribute whatsoever.
+        self.assertNotRegexpMatches(content, 'value')
+
+    def test_decompress_works_with_dates(self):
+        widget = UswdsDateWidget()
+        self.assertEqual(widget.decompress(date(2005, 6, 28)), [2005, 6, 28])
+
+    def test_decompress_works_with_none(self):
+        widget = UswdsDateWidget()
+        self.assertEqual(widget.decompress(None), [None, None, None])
+
+
+class DateFieldTests(SimpleTestCase):
+    def test_compress_returns_date_for_valid_dates(self):
+        field = UswdsDateField()
+        self.assertEqual(field.compress([2005, 6, 28]), date(2005, 6, 28))
+
+    def test_compress_raises_validation_errors_for_invalid_dates(self):
+        field = UswdsDateField()
+
+        with self.assertRaisesRegexp(
+            ValidationError,
+            'Invalid date: day is out of range for month.'
+        ):
+            field.compress([2001, 2, 31])
+
+    def test_compress_returns_none_when_data_list_is_falsy(self):
+        field = UswdsDateField()
+        self.assertEqual(field.compress(None), None)
+        self.assertEqual(field.compress([]), None)

--- a/uswds_forms/tests/test_radio_and_checkbox.py
+++ b/uswds_forms/tests/test_radio_and_checkbox.py
@@ -1,15 +1,7 @@
-import datetime
 from django.test import SimpleTestCase
 from django import forms
 
-from uswds_forms.date import UswdsDateWidget
 from uswds_forms import UswdsCheckboxSelectMultiple, UswdsRadioSelect
-
-
-def test_date_widget_decompress():
-    w = UswdsDateWidget()
-    d = datetime.date(2017, 5, 4)
-    assert w.decompress(d) == [2017, 5, 4]
 
 
 def test_checkbox_select_multiple_uses_unstyled_list():

--- a/uswds_forms/tests/test_widgets.py
+++ b/uswds_forms/tests/test_widgets.py
@@ -1,4 +1,5 @@
 import datetime
+from django.test import SimpleTestCase
 from django import forms
 
 from uswds_forms.date import UswdsDateWidget
@@ -31,3 +32,66 @@ def test_radio_select_uses_unstyled_list():
 
     # Note that this will fail if Django < 1.11.1!
     assert 'usa-unstyled-list' in MyForm().as_p()
+
+
+class CheckboxTests(SimpleTestCase):
+    def test_it_raises_error_when_id_is_not_present(self):
+        chk = UswdsCheckboxSelectMultiple(choices=[('1', 'foo')])
+        with self.assertRaisesRegexp(
+            ValueError,
+            'USWDS-style inputs must have "id" attributes'
+        ):
+            chk.render('my-checkboxes', '1')
+
+    def test_it_renders(self):
+        chk = UswdsCheckboxSelectMultiple(
+            {'id': 'baz'},
+            choices=[('1', 'foo'), ('2', 'bar')]
+        )
+        print(chk.render('my-checkboxes', '1'))
+        self.assertHTMLEqual(
+            chk.render('my-checkboxes', '1'),
+            ('<ul id="baz" class="usa-unstyled-list">'
+             '  <li>'
+             '    <input checked="checked" id="baz_0" name="my-checkboxes" '
+             '     type="checkbox" value="1" />'
+             '    <label for="baz_0">foo</label>'
+             '  </li>'
+             '  <li>'
+             '    <input id="baz_1" name="my-checkboxes" type="checkbox" '
+             '     value="2" />'
+             '    <label for="baz_1">bar</label>'
+             '  </li>'
+             '</ul>')
+        )
+
+
+class RadioTests(SimpleTestCase):
+    def test_it_raises_error_when_id_is_not_present(self):
+        rad = UswdsRadioSelect(choices=[('1', 'foo')])
+        with self.assertRaisesRegexp(
+            ValueError,
+            'USWDS-style inputs must have "id" attributes'
+        ):
+            rad.render('my-radios', '1')
+
+    def test_it_renders(self):
+        rad = UswdsRadioSelect(
+            {'id': 'baz'},
+            choices=[('1', 'foo'), ('2', 'bar')]
+        )
+        self.assertHTMLEqual(
+            rad.render('my-radios', '1'),
+            ('<ul id="baz" class="usa-unstyled-list">'
+             '  <li>'
+             '    <input checked="checked" id="baz_0" name="my-radios" '
+             '     type="radio" value="1" />'
+             '    <label for="baz_0">foo</label>'
+             '  </li>'
+             '  <li>'
+             '    <input id="baz_1" name="my-radios" type="radio" '
+             '     value="2" />'
+             '    <label for="baz_1">bar</label>'
+             '  </li>'
+             '</ul>')
+        )


### PR DESCRIPTION
Fixes #9.

To do:

- [x] Port over [`frontend/tests/test_widgets.py`](https://github.com/18F/calc/blob/develop/frontend/tests/test_widgets.py).
- [x] Port over [`frontend/tests/test_date.py`](https://github.com/18F/calc/blob/develop/frontend/tests/test_date.py).
