### PR TITLE
Update the name of USWDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://circleci.com/gh/18F/django-uswds-forms.svg?style=svg)](https://circleci.com/gh/18F/django-uswds-forms)
 
 This package provides [Django Forms][django-forms] integration with the
-[U.S. Web Design Standards][uswds].
+[U.S. Web Design System][uswds].
 
 This is a work-in-progress and may eventually be subsumed into
 [django-designstandards][] depending on what's best for everyone.


### PR DESCRIPTION
Updates the README to reflect that the project initially called the U.S. Web Design Standards is now called the U.S. Web Design System.